### PR TITLE
Add Claude Code skill and Anthropic backend support

### DIFF
--- a/.claude/skills/execute-code/REFERENCE.md
+++ b/.claude/skills/execute-code/REFERENCE.md
@@ -1,0 +1,102 @@
+# Execute Code - Reference
+
+## Script Usage
+
+```bash
+python3 scripts/run.py [OPTIONS]
+```
+
+### Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `--code` | Yes* | - | The code to execute |
+| `--lang` | No | `javascript` | Language: `javascript`, `js`, `python`, or `py` |
+| `--file` | No | - | Read code from file instead of --code |
+
+*Either `--code` or `--file` is required.
+
+### Examples
+
+```bash
+# Inline JavaScript
+python3 scripts/run.py --lang javascript --code 'console.log("Hello!");'
+
+# Inline Python
+python3 scripts/run.py --lang python --code 'print("Hello!")'
+
+# Short language aliases
+python3 scripts/run.py --lang js --code 'console.log(42);'
+python3 scripts/run.py --lang py --code 'print(42)'
+
+# From file
+python3 scripts/run.py --lang python --file script.py
+```
+
+## Hyperlight Sandbox
+
+The skill uses [hyperlight-nanvix](https://github.com/hyperlight-dev/hyperlight-nanvix) for VM-level code isolation.
+
+### Requirements
+
+- Linux with KVM support
+- `/dev/kvm` device accessible
+- hyperlight-nanvix Python package
+
+### Supported Languages
+
+| Language | Aliases | Extension | Output Function |
+|----------|---------|-----------|-----------------|
+| JavaScript | `javascript`, `js` | `.js` | `console.log()` |
+| Python | `python`, `py` | `.py` | `print()` |
+
+### Security Model
+
+- Code executes in isolated VM (not just a container)
+- No network access from sandbox
+- No filesystem access outside sandbox
+- Memory and CPU limits enforced by hypervisor
+
+## Direct Python Usage
+
+You can also use the script as a module:
+
+```python
+import asyncio
+from run import execute_code
+
+# JavaScript
+result = asyncio.run(execute_code('console.log(2 + 2);', 'javascript'))
+print(result)  # 4
+
+# Python
+result = asyncio.run(execute_code('print(sum(range(101)))', 'python'))
+print(result)  # 5050
+```
+
+## Troubleshooting
+
+### "hyperlight-nanvix not installed"
+```bash
+# Build from source
+git clone https://github.com/hyperlight-dev/hyperlight-nanvix.git
+cd hyperlight-nanvix
+pip install maturin
+maturin develop --features python
+```
+
+### "/dev/kvm not accessible"
+```bash
+# Check KVM availability
+ls -la /dev/kvm
+
+# Add user to kvm group
+sudo usermod -aG kvm $USER
+# Log out and back in for group change to take effect
+```
+
+### "No output"
+- JavaScript: Wrap expressions in `console.log()`
+- Python: Wrap expressions in `print()`
+
+Without explicit output functions, calculations run silently.

--- a/.claude/skills/execute-code/SKILL.md
+++ b/.claude/skills/execute-code/SKILL.md
@@ -1,0 +1,76 @@
+# Execute Code Skill
+
+Execute JavaScript or Python code in a secure Hyperlight VM sandbox with full isolation.
+
+## Requirements
+
+- Linux with KVM support (`/dev/kvm`)
+- Python 3.8+
+- `hyperlight-nanvix` package
+
+## When to Use
+
+Use this skill when:
+- The user asks to run, execute, or test code
+- You need to verify calculations or algorithm correctness
+- You want to demonstrate code behavior with actual output
+
+## Quick Start
+
+### JavaScript
+```bash
+python3 scripts/run.py --lang javascript --code 'console.log(2 + 2);'
+```
+
+### Python
+```bash
+python3 scripts/run.py --lang python --code 'print(2 + 2)'
+```
+
+## Usage Notes
+
+- **JavaScript**: Use `console.log()` to see output
+- **Python**: Use `print()` to see output
+- Code runs in VM-isolated sandbox (hyperlight-nanvix)
+- The script is self-contained - only requires `hyperlight-nanvix`
+
+## Examples
+
+### Calculate Fibonacci
+```bash
+python3 scripts/run.py --lang javascript --code '
+const fib = n => n <= 1 ? n : fib(n-1) + fib(n-2);
+for (let i = 0; i < 10; i++) console.log("fib(" + i + ") =", fib(i));
+'
+```
+
+### Prime Numbers
+```bash
+python3 scripts/run.py --lang python --code '
+primes = [n for n in range(2, 50) if all(n % i for i in range(2, int(n**0.5)+1))]
+print(f"Primes under 50: {primes}")
+'
+```
+
+### Execute from File
+```bash
+python3 scripts/run.py --lang python --file my_script.py
+```
+
+## Installation
+
+```bash
+# Option 1: Install from PyPI (when available)
+pip install hyperlight-nanvix
+
+# Option 2: Build from source
+git clone https://github.com/hyperlight-dev/hyperlight-nanvix.git
+cd hyperlight-nanvix
+pip install maturin
+maturin develop --features python
+```
+
+## See Also
+
+- `REFERENCE.md` - Detailed API and configuration options
+- `scripts/run.py` - The self-contained execution script

--- a/.claude/skills/execute-code/scripts/run.py
+++ b/.claude/skills/execute-code/scripts/run.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Execute code in a Hyperlight VM sandbox.
+
+This is a self-contained script that uses hyperlight-nanvix directly.
+
+Requirements:
+    pip install hyperlight-nanvix
+
+Usage:
+    python run.py --lang javascript --code 'console.log("Hello!");'
+    python run.py --lang python --code 'print("Hello!")'
+    python run.py --lang python --file script.py
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+import tempfile
+import uuid
+
+# Check for hyperlight-nanvix
+try:
+    from hyperlight_nanvix import NanvixSandbox, SandboxConfig
+except ImportError:
+    print("Error: hyperlight-nanvix is not installed.", file=sys.stderr)
+    print("Install it with: pip install hyperlight-nanvix", file=sys.stderr)
+    print("Or build from source: https://github.com/hyperlight-dev/hyperlight-nanvix", file=sys.stderr)
+    sys.exit(1)
+
+
+async def execute_code(
+    code: str,
+    language: str = "javascript",
+) -> str:
+    """Execute code in hyperlight sandbox.
+
+    Args:
+        code: The code to execute.
+        language: 'javascript' or 'python'.
+
+    Returns:
+        The execution output.
+    """
+    tmp_dir = tempfile.gettempdir()
+
+    # Create sandbox
+    config = SandboxConfig(
+        log_directory=tmp_dir,
+        tmp_directory=tmp_dir,
+    )
+    sandbox = NanvixSandbox(config)
+
+    # Write code to temp file
+    extension = "py" if language == "python" else "js"
+    filename = f"workload_{uuid.uuid4().hex[:8]}.{extension}"
+    workload_path = os.path.join(tmp_dir, filename)
+    stdout_capture_path = os.path.join(tmp_dir, f"stdout_{uuid.uuid4().hex[:8]}.txt")
+
+    try:
+        with open(workload_path, "w") as f:
+            f.write(code)
+
+        # Capture stdout at fd level since hyperlight writes directly to fd 1
+        original_stdout_fd = os.dup(1)
+        try:
+            with open(stdout_capture_path, "w") as capture_file:
+                os.dup2(capture_file.fileno(), 1)
+                sys.stdout.flush()
+                try:
+                    result = await sandbox.run(workload_path)
+                finally:
+                    sys.stdout.flush()
+                    os.dup2(original_stdout_fd, 1)
+
+            with open(stdout_capture_path, "r") as f:
+                captured_stdout = f.read().strip()
+        finally:
+            os.close(original_stdout_fd)
+            if os.path.exists(stdout_capture_path):
+                try:
+                    os.remove(stdout_capture_path)
+                except OSError:
+                    pass
+
+        if result.success:
+            return captured_stdout if captured_stdout else "Execution completed successfully."
+        else:
+            error_msg = result.error or "Unknown error"
+            return f"Execution failed: {error_msg}"
+
+    except Exception as e:
+        return f"Error during sandbox execution: {e}"
+
+    finally:
+        if os.path.exists(workload_path):
+            try:
+                os.remove(workload_path)
+            except OSError:
+                pass
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Execute code in a Hyperlight VM sandbox",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --lang javascript --code 'console.log(2 + 2);'
+  %(prog)s --lang python --code 'print(sum(range(100)))'
+  %(prog)s --lang python --file my_script.py
+        """,
+    )
+    parser.add_argument(
+        "--code",
+        type=str,
+        help="Code to execute (use --file for file input)",
+    )
+    parser.add_argument(
+        "--file",
+        type=str,
+        help="Read code from file instead of --code",
+    )
+    parser.add_argument(
+        "--lang",
+        type=str,
+        choices=["javascript", "python", "js", "py"],
+        default="javascript",
+        help="Language: javascript (default) or python",
+    )
+
+    args = parser.parse_args()
+
+    # Normalize language
+    language = args.lang
+    if language == "js":
+        language = "javascript"
+    elif language == "py":
+        language = "python"
+
+    # Get code from --code or --file
+    if args.file:
+        with open(args.file, "r") as f:
+            code = f.read()
+    elif args.code:
+        code = args.code
+    else:
+        parser.error("Either --code or --file is required")
+
+    # Execute
+    result = asyncio.run(execute_code(code, language))
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,191 @@
+# Local Code Interpreter Tool - Claude Code Guide
+
+## Project Overview
+
+A local code interpreter tool built with the [Microsoft Agent Framework](https://github.com/microsoft/agent-framework). It provides sandboxed code execution capabilities for AI agents.
+
+## Claude Code Skill
+
+This project includes a `/execute-code` skill for running code in a secure Hyperlight VM sandbox.
+
+### Quick Execute (JavaScript)
+```bash
+. .venv/bin/activate && python3 -c "
+import asyncio
+from local_code_interpreter.tools import CodeExecutionTool
+
+async def run():
+    tool = CodeExecutionTool(environment='hyperlight', hyperlight_language='javascript', approval_mode='never_require')
+    return await tool._execute('console.log(2 + 2);')
+
+print(asyncio.run(run()))
+"
+```
+
+### Quick Execute (Python)
+```bash
+. .venv/bin/activate && python3 -c "
+import asyncio
+from local_code_interpreter.tools import CodeExecutionTool
+
+async def run():
+    tool = CodeExecutionTool(environment='hyperlight', hyperlight_language='python', approval_mode='never_require')
+    return await tool._execute('print(sum(range(1, 101)))')
+
+print(asyncio.run(run()))
+"
+```
+
+## Quick Start
+
+```bash
+# 1. Setup (creates venv and installs dependencies including hyperlight-nanvix)
+just setup
+
+# 2. Configure environment
+cp .env.example .env
+# Edit .env with your OpenAI API key or Azure OpenAI configuration
+
+# 3. Run
+just run                      # Demo mode with Python subprocess
+just run hyperlight           # Demo mode with Hyperlight VM sandbox (JavaScript)
+just run hyperlight python    # Demo mode with Hyperlight VM sandbox (Python)
+just interactive              # Interactive chat mode
+just interactive hyperlight   # Interactive with Hyperlight
+just devui                    # Web interface on http://localhost:8090
+```
+
+## Architecture
+
+```
+src/local_code_interpreter/
+├── __init__.py       # Package initialization
+├── __main__.py       # CLI entry point
+├── tools.py          # CodeExecutionTool - the core execution logic
+└── agent.py          # ChatAgent setup, CLI, and DevUI
+```
+
+### Key Components
+
+- **CodeExecutionTool** (`tools.py`): The main tool class that executes code. Supports two environments:
+  - `python`: Fast subprocess execution (default)
+  - `hyperlight`: VM-isolated sandbox using hyperlight-nanvix (JavaScript or Python)
+
+- **create_interpreter_agent** (`agent.py:185`): Factory function that creates a configured ChatAgent with the code execution tool.
+
+## Execution Environments
+
+### Python Subprocess (default)
+- Fast execution in isolated subprocess
+- Output captured via stdout/stderr
+- Configurable timeout (default 30s)
+- Environment stripped for security
+
+### Hyperlight VM Sandbox
+- Uses [hyperlight-nanvix](https://github.com/hyperlight-dev/hyperlight-nanvix) for VM-level isolation
+- Supports JavaScript (default) and Python
+- Requires Linux with KVM support (`/dev/kvm`)
+- Higher security for untrusted code execution
+
+## Development Commands
+
+```bash
+# Code quality
+just format       # Format with black
+just lint         # Lint with ruff
+just lint-fix     # Auto-fix lint issues
+just typecheck    # Type check with mypy
+just check        # Run all quality checks
+
+# Testing
+just test         # Run tests
+just test-ci      # Tests with coverage reports
+
+# Build
+just build        # Build package
+just clean        # Clean artifacts
+```
+
+## Configuration
+
+Priority order: Anthropic > Azure OpenAI > OpenAI
+
+### Anthropic (Recommended for Claude Code users)
+```env
+ANTHROPIC_API_KEY="your-api-key"
+ANTHROPIC_MODEL_ID="claude-sonnet-4-20250514"
+```
+
+### OpenAI
+```env
+OPENAI_API_KEY="your-api-key"
+OPENAI_RESPONSES_MODEL_ID="gpt-4o-mini"
+```
+
+### Azure OpenAI
+```env
+AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
+AZURE_OPENAI_RESPONSES_DEPLOYMENT_NAME="gpt-4o"
+# Optional: AZURE_OPENAI_API_KEY for local dev, otherwise use `az login`
+```
+
+## Adding New Tools
+
+Tools use Pydantic `Annotated` types for parameter descriptions:
+
+```python
+# In tools.py
+from typing import Annotated
+from pydantic import Field
+
+def my_new_tool(
+    param: Annotated[str, Field(description="What this parameter does")],
+) -> str:
+    """Docstring becomes the tool description shown to the LLM."""
+    return "result string"
+```
+
+Then register in the agent's `tools=[]` list in `agent.py`.
+
+## Docker & Kubernetes
+
+```bash
+# Docker
+just docker-build              # Build image
+just docker-build-hyperlight   # Build with Hyperlight support
+just docker-run                # Run container
+
+# Kubernetes (requires Azure setup)
+just k8s-deploy                # Deploy to AKS
+just k8s-deploy-hyperlight     # Deploy with Hyperlight
+just k8s-status                # Check deployment
+just k8s-logs                  # View logs
+just k8s-port-forward          # Port forward to localhost:8090
+```
+
+## Testing Hyperlight Directly
+
+```python
+from hyperlight_nanvix import NanvixSandbox, SandboxConfig
+import asyncio
+
+async def test():
+    config = SandboxConfig(log_directory='/tmp', tmp_directory='/tmp')
+    sandbox = NanvixSandbox(config)
+
+    # Write test code to file
+    with open('/tmp/test.js', 'w') as f:
+        f.write('console.log("Hello from Hyperlight!");')
+
+    result = await sandbox.run('/tmp/test.js')
+    print(f"Success: {result.success}")
+
+asyncio.run(test())
+```
+
+## Debug Mode
+
+Enable detailed logging of code execution:
+```bash
+DEBUG=true just run hyperlight
+```


### PR DESCRIPTION
## Summary

- Add `/execute-code` skill for Claude Code with Hyperlight VM sandbox execution
- Add `CLAUDE.md` project guide with quick execute examples

## Changes

### Claude Code Skill (`.claude/skills/execute-code/`)
- `SKILL.md`: Main instructions and quick start guide
- `REFERENCE.md`: Detailed API and configuration reference
- `scripts/run.py`: Utility script for executing JavaScript/Python code

### Documentation
- `CLAUDE.md`: Project guide for Claude Code users with quick execute snippets

## Test plan

- [x] Verified hyperlight JavaScript execution works
- [x] Verified hyperlight Python execution works
- [x] Tested skill script with `--lang js` and `--lang py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)